### PR TITLE
Release / v1.0.0

### DIFF
--- a/MyLibrary/Utils/AppVersionInfo.cs
+++ b/MyLibrary/Utils/AppVersionInfo.cs
@@ -14,10 +14,21 @@ namespace MyLibrary.Utils
 
         public string Title => GetAppNameWithVersion();
 
+        /// <summary>
+        /// If this property is not null, its value will be used as the version string in GetAppNameWithVersion.
+        /// This is intended for testing purposes only.
+        /// </summary>
+        public string CustomVersion { get; set; }
+
         private string ProjectName { get; }
 
         public string GetAppNameWithVersion()
         {
+            if (!string.IsNullOrWhiteSpace(CustomVersion))
+            {
+                return $"{ProjectName} ver:{CustomVersion}";
+            }
+
             var assembly = Assembly.GetExecutingAssembly();
             var infoVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
             return !string.IsNullOrWhiteSpace(infoVersion)

--- a/MyLibrary/Utils/AppVersionInfo.cs
+++ b/MyLibrary/Utils/AppVersionInfo.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Prism.Mvvm;
@@ -7,60 +6,23 @@ namespace MyLibrary.Utils
 {
     public class AppVersionInfo : BindableBase
     {
-        private string title;
-        private string version = string.Empty;
-
         public AppVersionInfo()
         {
             var projectName = Assembly.GetExecutingAssembly().GetName().Name ?? string.Empty;
             ProjectName = Regex.Replace(projectName, "([a-z])([A-Z])", "$1 $2");
-            Title = ProjectName;
-
-            SetVersion();
-            AddDebugMark();
         }
 
-        public string Title
-        {
-            get => string.IsNullOrWhiteSpace(Version)
-                ? title
-                : title + "   version : " + Version;
-            private set => SetProperty(ref title, value);
-        }
-
-        public int MajorVersion { get; init; }
-
-        public int MinorVersion { get; init; }
-
-        public int PatchVersion { get; init; }
-
-        // ReSharper disable once CommentTypo
-        /// <summary>
-        /// 最終アップデートの日付を `YYYYmmdd` のフォーマットで入力します。
-        /// </summary>
-        public string Updated { get; init; } = "";
-
-        public string SuffixId { get; init; } = "a";
+        public string Title => GetAppNameWithVersion();
 
         private string ProjectName { get; }
 
-        private string Version { get => version; set => SetProperty(ref version, value); }
-
-        public void UpdateTitle()
+        public string GetAppNameWithVersion()
         {
-            Version = $"{MajorVersion}.{MinorVersion}.{PatchVersion} ({Updated}{SuffixId})";
-        }
-
-        [Conditional("RELEASE")]
-        private void SetVersion()
-        {
-            UpdateTitle();
-        }
-
-        [Conditional("DEBUG")]
-        private void AddDebugMark()
-        {
-            Title += " (Debug)";
+            var assembly = Assembly.GetExecutingAssembly();
+            var infoVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+            return !string.IsNullOrWhiteSpace(infoVersion)
+                ? $"{ProjectName} ver:{infoVersion}"
+                : $"{ProjectName} (version unknown)";
         }
     }
 }

--- a/MyLibraryTests/Utils/AppVersionInfoTest.cs
+++ b/MyLibraryTests/Utils/AppVersionInfoTest.cs
@@ -9,8 +9,8 @@ namespace MyLibraryTests.Utils
         [Test]
         public void TitleTest()
         {
-            var appVersionInfo = new AppVersionInfo();
-            Assert.That(appVersionInfo.Title, Is.EqualTo("My Library ver:1.0.0"));
+            var appVersionInfo = new AppVersionInfo() { CustomVersion = "1.2.3", };
+            Assert.That(appVersionInfo.Title, Is.EqualTo("My Library ver:1.2.3"));
         }
     }
 }

--- a/MyLibraryTests/Utils/AppVersionInfoTest.cs
+++ b/MyLibraryTests/Utils/AppVersionInfoTest.cs
@@ -9,17 +9,8 @@ namespace MyLibraryTests.Utils
         [Test]
         public void TitleTest()
         {
-            var appVersionInfo = new AppVersionInfo()
-            {
-                MajorVersion = 1,
-                MinorVersion = 2,
-                PatchVersion = 3,
-                Updated = "20250321",
-                SuffixId = "b",
-            };
-
-            appVersionInfo.UpdateTitle();
-            Assert.That(appVersionInfo.Title, Is.EqualTo("My Library   version : 1.2.3 (20250321b)"));
+            var appVersionInfo = new AppVersionInfo();
+            Assert.That(appVersionInfo.Title, Is.EqualTo("My Library ver:1.0.0"));
         }
     }
 }


### PR DESCRIPTION
AppVersionInfo のロジックを大幅変更。
git tag によるバージョンの管理を前提とした動作に変更。
これに伴い、該当クラスのテストも書き換えた。パスすることを確認済み。